### PR TITLE
Build .deb for Focal, Jammy, and Noble via CI matrix

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -15,10 +15,17 @@ jobs:
         include:
           - ubuntu: "20.04"
             codename: focal
+            # GCC 9 (default on Focal) has incomplete C++20 support; use GCC 10
+            extra_pkgs: "gcc-10 g++-10"
+            cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10"
           - ubuntu: "22.04"
             codename: jammy
+            extra_pkgs: ""
+            cmake_compiler_flags: ""
           - ubuntu: "24.04"
             codename: noble
+            extra_pkgs: ""
+            cmake_compiler_flags: ""
     container:
       image: ubuntu:${{ matrix.ubuntu }}
 
@@ -34,7 +41,8 @@ jobs:
             ca-certificates git curl pkg-config \
             build-essential cmake \
             libgdal-dev \
-            file dpkg-dev
+            file dpkg-dev \
+            ${{ matrix.extra_pkgs }}
           update-ca-certificates
           git config --system http.sslCAinfo /etc/ssl/certs/ca-certificates.crt
           # sanity checks
@@ -47,7 +55,8 @@ jobs:
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=OFF \
-            -DGDAL_USE_STATIC_LIBS=OFF
+            -DGDAL_USE_STATIC_LIBS=OFF \
+            ${{ matrix.cmake_compiler_flags }}
 
       - name: Build
         run: cmake --build build -j"$(nproc)"

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,4 +1,4 @@
-name: build-and-test-deb (noble only)
+name: build-and-test-deb
 
 on:
   push:
@@ -9,7 +9,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ubuntu:24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ubuntu: "20.04"
+            codename: focal
+          - ubuntu: "22.04"
+            codename: jammy
+          - ubuntu: "24.04"
+            codename: noble
+    container:
+      image: ubuntu:${{ matrix.ubuntu }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -29,7 +41,7 @@ jobs:
           gdal-config --version
           pkg-config --modversion gdal
 
-      - name: Configure (C++20; disable tests in CI)
+      - name: Configure
         run: |
           set -eux
           cmake -B build \
@@ -42,31 +54,47 @@ jobs:
 
       - name: Package (.deb via CPack)
         run: |
+          set -eux
           cpack -B build/dist -G DEB --config build/CPackConfig.cmake
+          # Append Ubuntu codename so all three artifacts are distinct
+          for f in build/dist/*.deb; do
+            mv "$f" "${f%.deb}-${{ matrix.codename }}.deb"
+          done
           ls -l build/dist
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4
         with:
-          name: opendsas-noble
+          name: opendsas-${{ matrix.codename }}
           path: build/dist/*.deb
 
   test-install:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ubuntu: "20.04"
+            codename: focal
+          - ubuntu: "22.04"
+            codename: jammy
+          - ubuntu: "24.04"
+            codename: noble
+
     steps:
       - name: Download .deb
         uses: actions/download-artifact@v4
         with:
-          name: opendsas-noble
+          name: opendsas-${{ matrix.codename }}
           path: dist
 
       - name: Show downloaded files
         run: ls -lah dist
 
-      - name: Test install inside clean noble
+      - name: Test install inside clean Ubuntu ${{ matrix.ubuntu }}
         run: |
-          docker run --rm -v "$PWD/dist:/pkg:ro" ubuntu:24.04 bash -lc '
+          docker run --rm -v "$PWD/dist:/pkg:ro" ubuntu:${{ matrix.ubuntu }} bash -lc '
             set -euo pipefail
             export DEBIAN_FRONTEND=noninteractive
             apt-get update
@@ -84,6 +112,14 @@ jobs:
     needs: [build, test-install]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opendsas-focal
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: opendsas-jammy
+          path: dist
       - uses: actions/download-artifact@v4
         with:
           name: opendsas-noble

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -15,15 +15,18 @@ jobs:
         include:
           - ubuntu: "20.04"
             codename: focal
+            gdal_pkg: libgdal26
             # GCC 9 (default on Focal) has incomplete C++20 support; use GCC 10
             extra_pkgs: "gcc-10 g++-10"
             cmake_compiler_flags: "-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10"
           - ubuntu: "22.04"
             codename: jammy
+            gdal_pkg: libgdal30
             extra_pkgs: ""
             cmake_compiler_flags: ""
           - ubuntu: "24.04"
             codename: noble
+            gdal_pkg: libgdal34
             extra_pkgs: ""
             cmake_compiler_flags: ""
     container:
@@ -52,14 +55,11 @@ jobs:
       - name: Configure
         run: |
           set -eux
-          # Detect the installed GDAL runtime package (soname differs per distro)
-          GDAL_PKG=$(dpkg -l | awk '/^ii\s+libgdal[0-9]/{print $2}' | head -1)
-          echo "Detected GDAL runtime package: $GDAL_PKG"
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=OFF \
             -DGDAL_USE_STATIC_LIBS=OFF \
-            -DCPACK_DEBIAN_PACKAGE_DEPENDS="libc6 (>= 2.17), libstdc++6 (>= 5), libgomp1, ${GDAL_PKG}" \
+            "-DCPACK_DEBIAN_PACKAGE_DEPENDS=libc6 (>= 2.17), libstdc++6 (>= 5), libgomp1, ${{ matrix.gdal_pkg }}" \
             ${{ matrix.cmake_compiler_flags }}
 
       - name: Build

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -52,10 +52,14 @@ jobs:
       - name: Configure
         run: |
           set -eux
+          # Detect the installed GDAL runtime package (soname differs per distro)
+          GDAL_PKG=$(dpkg -l | awk '/^ii\s+libgdal[0-9]/{print $2}' | head -1)
+          echo "Detected GDAL runtime package: $GDAL_PKG"
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_TESTING=OFF \
             -DGDAL_USE_STATIC_LIBS=OFF \
+            -DCPACK_DEBIAN_PACKAGE_DEPENDS="libc6 (>= 2.17), libstdc++6 (>= 5), libgomp1, ${GDAL_PKG}" \
             ${{ matrix.cmake_compiler_flags }}
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(argparse)
 
 # GDAL (module mode works on Debian/Ubuntu)
-find_package(GDAL CONFIG REQUIRED)
+find_package(GDAL REQUIRED)
 
 # Boost headers (no specific components)
 find_package(Boost REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,9 @@ set(CPACK_PACKAGE_CONTACT "Boyuan Lu blu38@wisc.edu")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenDSAS — high-performance Digital Shoreline Analysis System (CLI)")
 set(CPACK_DEBIAN_PACKAGE_SECTION "science")
 
-# Let dpkg-shlibdeps compute runtime shared-library deps automatically
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+# Runtime deps are injected by the CI per-distro (GDAL soname varies).
+# Disable shlibdeps to avoid hangs in stripped-down container environments.
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
 
 # Optional: ship docs
 # install(FILES LICENSE README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,55 @@
-FROM debian:bullseye
+# ── Stage 1: build a static GDAL on Debian Bullseye (glibc 2.31) ─────────────
+# Bullseye is used so the binary's glibc floor matches Ubuntu 20.04 (Focal).
+FROM debian:bullseye AS gdal-builder
 
-# Install build tools and GDAL dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    cmake \
-    git \
-    libcurl4-openssl-dev \
-    libgeos-dev \
-    libproj-dev \
-    libtiff-dev \
-    libjpeg-dev \
-    sqlite3 \
-    zlib1g-dev \
-    pkg-config \
-    ninja-build \
-    libboost-all-dev \
-    libomp-dev \
-    && apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git ninja-build pkg-config ca-certificates \
+    libcurl4-openssl-dev libgeos-dev libproj-dev \
+    libtiff-dev libjpeg-dev libsqlite3-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Set workdir
 WORKDIR /gdal
+RUN git clone --depth 1 --branch v3.8.5 https://github.com/OSGeo/gdal.git .
 
-# Clone and build GDAL from source
-RUN git clone --branch v3.8.5 https://github.com/OSGeo/gdal.git .
-
-# Configure and build GDAL with CMake
-RUN cmake -B build -S . -GNinja \
+RUN cmake -B build -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
     -DGDAL_BUILD_TOOLS=OFF \
     -DGDAL_USE_EXTERNAL_LIBS=ON \
-    -DGDAL_BUILD_TESTING=OFF
+    -DGDAL_BUILD_TESTING=OFF \
+    -DCMAKE_INSTALL_PREFIX=/opt/gdal \
+    && cmake --build build -j$(nproc) \
+    && cmake --install build
 
-RUN cmake --build build -j$(nproc)
-RUN cmake --install build --prefix /usr/local
+# ── Stage 2: build the app ────────────────────────────────────────────────────
+FROM debian:bullseye AS app-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git pkg-config ca-certificates \
+    libcurl4-openssl-dev libgeos-dev libproj-dev \
+    libtiff-dev libjpeg-dev libsqlite3-dev zlib1g-dev \
+    libboost-all-dev libomp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=gdal-builder /opt/gdal /opt/gdal
 
 WORKDIR /app
 COPY . .
 
-RUN cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
+RUN cmake -B build -S . \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_PREFIX_PATH=/opt/gdal \
     && cmake --build build -j$(nproc) \
-    && cmake --install build
+    && cmake --install build --prefix /usr/local
+
+# ── Stage 3: minimal runtime image ───────────────────────────────────────────
+FROM debian:bullseye-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgeos-c1 libproj19 libcurl4 libtiff5 libsqlite3-0 libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=app-builder /usr/local/bin/dsas /usr/local/bin/dsas
+
+ENTRYPOINT ["dsas"]


### PR DESCRIPTION
The previous workflow only built for Ubuntu 24.04 (Noble), whose binary linked against a GDAL soname not present on other Ubuntu LTS releases. Switch to a build matrix (20.04/22.04/24.04) so each .deb depends on its distro's own system GDAL.  Also refactor the Dockerfile into a proper multi-stage build (gdal-builder → app-builder → slim runtime).