### PR TITLE
Match output format to input format (GeoJSON in → GeoJSON out)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,27 @@
 #include "transect.hpp"
 #include "utility.hpp"
 
-// --------------------------- runners ----------------------------------
+// --------------------------- helpers ----------------------------------
 namespace {
+
+// If the input file is GeoJSON, replace the .shp default extension on output
+// paths so that output format matches input format.
+void sync_output_format(const std::string &input_path) {
+  auto ext = std::filesystem::path(input_path).extension().string();
+  if (ext != ".geojson" && ext != ".json") return;
+  auto fix = [](std::string &p) {
+    std::filesystem::path fp(p);
+    if (fp.extension() == ".shp") {
+      fp.replace_extension(".geojson");
+      p = fp.string();
+    }
+  };
+  fix(dsas::options.transect_path);
+  fix(dsas::options.intersect_path);
+}
+
+// --------------------------- runners ----------------------------------
+
 void cal_erosion_rate(std::vector<dsas::TransectLine>& transects) {
   for (auto& transect : transects) {
     auto intersects = transect.intersects;
@@ -37,6 +56,7 @@ void print_messages() {
 }
 
 void run_root() {
+  sync_output_format(dsas::options.baseline_path);
   print_messages();
 
   auto baselines = dsas::load_baselines_shp(dsas::options.baseline_path,
@@ -65,6 +85,7 @@ void run_root() {
 }
 
 void run_cast() {
+  sync_output_format(dsas::options.baseline_path);
   auto baselines = dsas::load_baselines_shp(dsas::options.baseline_path,
                                             dsas::options.baseline_id_field);
   auto transects = dsas::generate_transects(baselines);
@@ -73,6 +94,7 @@ void run_cast() {
 }
 
 void run_cal() {
+  sync_output_format(dsas::options.shoreline_path);
   auto shorelines = dsas::load_shorelines_shp(dsas::options.shoreline_path,
                                               dsas::options.date_field.c_str());
   auto transects = dsas::load_transects_from_shp(dsas::options.transect_path);

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -5,6 +5,7 @@
 #ifndef SRC_UTILITY_HPP_
 #define SRC_UTILITY_HPP_
 
+#include <nlohmann/json.hpp>
 #include <shapefil.h>
 
 #include <algorithm>
@@ -148,7 +149,82 @@ inline void write_prj(const std::filesystem::path &shp_path,
   if (f) f << prj;
 }
 
-// GCOVR_EXCL_START
+// Build a JSON properties object from a ShpSavable's names + values tuple.
+template <typename Tuple, size_t... Is>
+nlohmann::json tuple_to_json_props(const std::vector<std::string> &names,
+                                   const Tuple &t,
+                                   std::index_sequence<Is...>) {
+  nlohmann::json props;
+  ((props[names[Is]] = std::get<Is>(t)), ...);
+  return props;
+}
+
+template <typename T>
+requires std::derived_from<T, ShpSavable<typename T::value_tuple>>
+nlohmann::json shape_to_props(const T *shape) {
+  auto values = shape->get_values();
+  return tuple_to_json_props(
+      shape->get_names(), values,
+      std::make_index_sequence<
+          std::tuple_size_v<typename T::value_tuple>>{});
+}
+
+// ---- GeoJSON writers ----
+
+template <typename T>
+requires std::derived_from<T, MultiLine<Point>> &&
+         std::derived_from<T, ShpSavable<typename T::value_tuple>>
+void save_lines_geojson(const std::vector<T *> &lines, const std::string &prj,
+                        const std::filesystem::path &output_path) {
+  nlohmann::json fc;
+  fc["type"] = "FeatureCollection";
+  fc["crs"] = {{"type", "name"}, {"properties", {{"name", prj}}}};
+  fc["features"] = nlohmann::json::array();
+
+  for (const auto *shape : lines) {
+    if (shape->size() < 1) continue;
+    nlohmann::json coords = nlohmann::json::array();
+    for (const auto &pt : *shape) {
+      coords.push_back({pt.get_x(), pt.get_y()});
+    }
+    nlohmann::json feature;
+    feature["type"] = "Feature";
+    feature["geometry"] = {{"type", "LineString"}, {"coordinates", std::move(coords)}};
+    feature["properties"] = shape_to_props(shape);
+    fc["features"].push_back(std::move(feature));
+  }
+
+  std::ofstream f(output_path);
+  if (!f) OPENDSAS_THROW("Cannot write: " + output_path.string());
+  f << fc.dump(2);
+}
+
+template <typename T>
+requires std::derived_from<T, PointAttribute<double>> &&
+         std::derived_from<T, ShpSavable<typename T::value_tuple>>
+void save_points_geojson(const std::vector<T *> &shapes, const std::string &prj,
+                         const std::filesystem::path &output_path) {
+  nlohmann::json fc;
+  fc["type"] = "FeatureCollection";
+  fc["crs"] = {{"type", "name"}, {"properties", {{"name", prj}}}};
+  fc["features"] = nlohmann::json::array();
+
+  for (auto *shape : shapes) {
+    nlohmann::json feature;
+    feature["type"] = "Feature";
+    feature["geometry"] = {{"type", "Point"},
+                            {"coordinates", {shape->get_x(), shape->get_y()}}};
+    feature["properties"] = shape_to_props(shape);
+    fc["features"].push_back(std::move(feature));
+  }
+
+  std::ofstream f(output_path);
+  if (!f) OPENDSAS_THROW("Cannot write: " + output_path.string());
+  f << fc.dump(2);
+}
+
+// ---- Shapefile + dispatch writers ----
+
 template <typename T>
 requires std::derived_from<T, MultiLine<Point>> &&
          std::derived_from<T, ShpSavable<typename T::value_tuple>>
@@ -161,6 +237,13 @@ void save_lines(const std::vector<T *> &lines, const std::string &prj,
     OPENDSAS_THROW("Projection setting failed");
   }
 
+  auto ext = output_path.extension().string();
+  if (ext == ".geojson" || ext == ".json") {
+    save_lines_geojson(lines, prj, output_path);
+    return;
+  }
+
+  // GCOVR_EXCL_START
   auto base = output_path;
   base.replace_extension("");
   const std::string base_str = base.string();
@@ -202,8 +285,8 @@ void save_lines(const std::vector<T *> &lines, const std::string &prj,
   SHPClose(hSHP);
   DBFClose(hDBF);
   write_prj(output_path, prj);
+  // GCOVR_EXCL_STOP
 }
-// GCOVR_EXCL_STOP
 
 template <typename T>
 requires std::derived_from<T, PointAttribute<double>> &&
@@ -215,6 +298,12 @@ void save_points(const std::vector<T *> &shapes, const std::string &prj,
   }
   if (!looks_like_proj(prj)) {
     OPENDSAS_THROW("Projection setting failed");
+  }
+
+  auto ext = output_path.extension().string();
+  if (ext == ".geojson" || ext == ".json") {
+    save_points_geojson(shapes, prj, output_path);
+    return;
   }
 
   // GCOVR_EXCL_START

--- a/tests/intersect.test.cpp
+++ b/tests/intersect.test.cpp
@@ -1,7 +1,9 @@
 #include "intersect.hpp"
 
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 
+#include <fstream>
 #include <memory>
 
 #include "utility.hpp"
@@ -29,37 +31,40 @@ TEST(TestIntersect, test_save_intersects) {
   auto tmp_file = std::filesystem::temp_directory_path() / "intersects.shp";
   options.intersect_path = tmp_file.string();
 
-  {
-    std::vector<std::unique_ptr<IntersectPoint>> intersections;
-    auto p1 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date1, dist2ref1);
-    auto p2 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date2, dist2ref2);
-    auto p3 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date3, dist2ref3);
+  auto make_pts = [&]() {
+    std::vector<std::unique_ptr<IntersectPoint>> v;
+    v.push_back(std::make_unique<IntersectPoint>(
+        fake_point, fake_tid, fake_sid, fake_bid, date1, dist2ref1));
+    v.push_back(std::make_unique<IntersectPoint>(
+        fake_point, fake_tid, fake_sid, fake_bid, date2, dist2ref2));
+    v.push_back(std::make_unique<IntersectPoint>(
+        fake_point, fake_tid, fake_sid, fake_bid, date3, dist2ref3));
+    return v;
+  };
 
-    intersections.push_back(std::move(p1));
-    intersections.push_back(std::move(p2));
-    intersections.push_back(std::move(p3));
-    save_intersects(intersections, prj);
+  // Shapefile output
+  options.intersect_path = tmp_file.string();
+  { save_intersects(make_pts(), prj); }
+
+  // GeoJSON output — verify the file is valid JSON with expected structure
+  auto geojson_file = std::filesystem::temp_directory_path() / "intersects.geojson";
+  options.intersect_path = geojson_file.string();
+  { save_intersects(make_pts(), prj); }
+  {
+    std::ifstream f(geojson_file);
+    ASSERT_TRUE(f.good());
+    auto j = nlohmann::json::parse(f);
+    ASSERT_EQ(j["type"].get<std::string>(), "FeatureCollection");
+    ASSERT_EQ(j["features"].size(), 3u);
+    ASSERT_EQ(j["features"][0]["geometry"]["type"].get<std::string>(), "Point");
   }
+
   {
     std::vector<std::unique_ptr<IntersectPoint>> intersections;
     ASSERT_THROW(save_intersects(intersections, prj), std::runtime_error);
   }
   {
-    std::vector<std::unique_ptr<IntersectPoint>> intersections;
-    auto p1 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date1, dist2ref1);
-    auto p2 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date2, dist2ref2);
-    auto p3 = std::make_unique<dsas::IntersectPoint>(
-        fake_point, fake_tid, fake_sid, fake_bid, date3, dist2ref3);
-
-    intersections.push_back(std::move(p1));
-    intersections.push_back(std::move(p2));
-    intersections.push_back(std::move(p3));
     prj = "INVALID_PROJ_STRING";
-    ASSERT_THROW(save_intersects(intersections, prj), std::runtime_error);
+    ASSERT_THROW(save_intersects(make_pts(), prj), std::runtime_error);
   }
 }

--- a/tests/transect.test.cpp
+++ b/tests/transect.test.cpp
@@ -202,12 +202,25 @@ TEST_F(TransectTest, test_save_transect) {
   auto prj = get_shp_proj(shoreline_shp_path.string().c_str());
   std::vector<Point> points{{0, 0}, {1, 1}, {2, 0}, {3, 1},
                             {3, 0}, {4, 1}, {4, 0}};
-  auto tmp_file = std::filesystem::temp_directory_path() / "tran.shp";
-  options.transect_path = tmp_file.string();
   baseline = std::make_unique<Baseline>(points, 0);
   auto transects_lines = create_transects_from_baseline(*baseline);
+
+  // Shapefile output
+  options.transect_path =
+      (std::filesystem::temp_directory_path() / "tran.shp").string();
   { save_transect(transects_lines, prj); }
   { save_transect(transects_lines, prj, true); }
+
+  // GeoJSON output — lines
+  options.transect_path =
+      (std::filesystem::temp_directory_path() / "tran.geojson").string();
+  { save_transect(transects_lines, prj); }
+
+  // GeoJSON output — points
+  options.transect_path =
+      (std::filesystem::temp_directory_path() / "tran_pts.geojson").string();
+  { save_transect(transects_lines, prj, true); }
+
   {
     transects_lines.clear();
     ASSERT_THROW(save_transect(transects_lines, prj), std::runtime_error);


### PR DESCRIPTION
## Summary

- When input files are GeoJSON, output files (`transects`, `intersects`) are now written as GeoJSON FeatureCollections instead of Shapefiles
- When input is Shapefile, output remains Shapefile — no behaviour change for existing users
- Dispatch happens inside `save_lines`/`save_points` based on the output path extension (`.geojson`/`.json` → JSON writer, otherwise shapelib)
- `sync_output_format()` in `main.cpp` replaces the `.shp` default extension on output paths when the input file is GeoJSON — no extra flags required from the user
- GeoJSON output includes a `"crs"` block mirroring the input projection string, so QGIS/ArcGIS/GDAL can parse the CRS

## Test plan

- [x] All 33 unit tests pass locally
- [x] `test_save_transect`: added GeoJSON line and point output cases
- [x] `test_save_intersects`: added GeoJSON output case + asserts valid FeatureCollection with `Point` geometry features
- [x] Explicit `.shp` output still writes Shapefile (backward compatible)

> Depends on #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)