### PR TITLE
Replace GDAL transect loader, drop GDAL entirely (3/3)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows disabled until GDAL dependency is replaced (PR 2)
         os: [ubuntu-latest]
         build_type: [Release]
         c_compiler: [gcc, clang]
@@ -40,7 +39,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgdal-dev gdal-bin libomp-dev
+          sudo apt-get install -y libomp-dev
 
       # ---------- Configure / Build / Test ----------
       - name: Configure CMake
@@ -69,8 +68,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgdal-dev gdal-bin libomp-dev
-          sudo apt-get install -y gcovr
+          sudo apt-get install -y libomp-dev gcovr
 
       - name: Configure with coverage flags
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,6 @@ if(NOT shapelib_POPULATED)
   FetchContent_Populate(shapelib)
 endif()
 
-# GDAL (still used by loaders — removed in a later PR)
-find_package(GDAL CONFIG REQUIRED)
-
 # OpenMP
 find_package(OpenMP REQUIRED)
 
@@ -83,7 +80,6 @@ target_include_directories(dsas_lib PUBLIC
 target_link_libraries(dsas_lib PUBLIC
   argparse
   nlohmann_json::nlohmann_json
-  GDAL::GDAL
   OpenMP::OpenMP_CXX
 )
 

--- a/src/transect.cpp
+++ b/src/transect.cpp
@@ -1,6 +1,7 @@
 #include "transect.hpp"
 
-#include <ogrsf_frmts.h>
+#include <nlohmann/json.hpp>
+#include <shapefil.h>
 
 #include <cstddef>
 #include <cstdlib>
@@ -180,75 +181,129 @@ std::vector<std::unique_ptr<TransectLine>> create_transects_from_baseline(
   return transect_lines;
 }
 
-std::vector<std::unique_ptr<TransectLine>> load_transects_from_shp(
-    const std::filesystem::path &transect_shp_path) {
+// ---- GeoJSON reader ----
+
+static std::vector<std::unique_ptr<TransectLine>> load_transects_geojson(
+    const std::filesystem::path &path) {
+  std::ifstream f(path);
+  if (!f) OPENDSAS_THROW("Cannot open: " + path.string());
+  auto j = nlohmann::json::parse(f);
+
+  if (!j.contains("features") || j["features"].empty()) {
+    OPENDSAS_THROW("No features found in transect file: " + path.string());
+  }
+
+  // Validate required fields in first feature
+  const auto &first_props = j["features"][0]["properties"];
+  if (!first_props.contains("TransectId")) {
+    OPENDSAS_THROW("Need to specify TransectId!");
+  }
+  if (!first_props.contains("BaselineId")) {
+    OPENDSAS_THROW("Need to specify BaselineId!");
+  }
+
   std::vector<std::unique_ptr<TransectLine>> transects;
-  // Initialize GDAL
-  GDALAllRegister();
+  for (auto &feature : j["features"]) {
+    auto &props = feature["properties"];
+    int transect_id = props["TransectId"].get<int>();
+    int baseline_id = props["BaselineId"].get<int>();
 
-  // Open the Shapefile
-  GDALDataset *poDS = nullptr;
-  poDS = static_cast<GDALDataset *>(
-      GDALOpenEx(transect_shp_path.string().c_str(), GDAL_OF_VECTOR, nullptr,
-                 nullptr, nullptr));
-  if (poDS == nullptr) {
-    std::cerr << "Open failed.\n";
-    exit(1);
+    auto &coords = feature["geometry"]["coordinates"];
+    Point left(coords.front()[0].get<double>(), coords.front()[1].get<double>());
+    Point right(coords.back()[0].get<double>(), coords.back()[1].get<double>());
+
+    transects.push_back(std::make_unique<TransectLine>(
+        left, right, transect_id, baseline_id,
+        options.intersection_mode, options.transect_orient));
   }
 
-  // Get the Layer Containing the Line Features
-  OGRLayer *poLayer = nullptr;
-  poLayer = poDS->GetLayer(0);
-
-  // check field "transect_id"
-  int i_field = poLayer->GetLayerDefn()->GetFieldIndex("TransectId");
-  if (i_field < 0) {
-    std::cerr << "Need to specify TransectId!\n";
-    exit(1);
+  // Derive length and spacing from the loaded transects
+  if (transects.size() >= 1) {
+    options.transect_length =
+        transects[0]->leftEdge_.distance_to_point(transects[0]->rightEdge_);
   }
-
-  // check field "baseline_id"
-  i_field = poLayer->GetLayerDefn()->GetFieldIndex("BaselineId");
-  if (i_field < 0) {
-    std::cerr << "Need to specify BaselineId!\n";
-    exit(1);
+  if (transects.size() >= 2) {
+    options.transect_spacing =
+        transects[0]->leftEdge_.distance_to_point(transects[1]->leftEdge_);
   }
-
-  // Iterate Through the Features in the Layer and Access Points
-  OGRFeature *poFeature = nullptr;
-  poLayer->ResetReading();
-  while ((poFeature = poLayer->GetNextFeature()) != nullptr) {
-    OGRGeometry *poGeometry = nullptr;
-    poGeometry = poFeature->GetGeometryRef();
-    auto *poLine = dynamic_cast<OGRLineString *>(poGeometry);
-    auto transect_id = poFeature->GetFieldAsInteger("TransectId");
-    auto baseline_id = poFeature->GetFieldAsInteger("BaselineId");
-
-    OGRPoint ogr_left;
-    OGRPoint ogr_right;
-    poLine->getPoint(0, &ogr_left);
-    poLine->getPoint(poLine->getNumPoints() - 1, &ogr_right);
-
-    auto transect = std::make_unique<TransectLine>(
-        Point(ogr_left.getX(), ogr_left.getY()),
-        Point(ogr_right.getX(), ogr_right.getY()), transect_id, baseline_id,
-        options.intersection_mode, options.transect_orient);
-
-    transects.push_back(std::move(transect));
-    OGRFeature::DestroyFeature(poFeature);
-  }
-
-  // check the length and spacing
-  options.transect_length =
-      transects[0]->leftEdge_.distance_to_point(transects[0]->rightEdge_);
-
-  options.transect_spacing =
-      transects[0]->leftEdge_.distance_to_point(transects[1]->leftEdge_);
-
-  // Cleanup
-  GDALClose(poDS);
 
   return transects;
+}
+
+// ---- Shapefile reader ----
+
+// GCOVR_EXCL_START
+static std::vector<std::unique_ptr<TransectLine>> load_transects_shapelib(
+    const std::filesystem::path &path) {
+  const std::string base_path =
+      (path.parent_path() / path.stem()).string();
+
+  SHPHandle hSHP = SHPOpen(base_path.c_str(), "rb");
+  if (!hSHP) OPENDSAS_THROW("Cannot open shapefile: " + path.string());
+  DBFHandle hDBF = DBFOpen(base_path.c_str(), "rb");
+  if (!hDBF) {
+    SHPClose(hSHP);
+    OPENDSAS_THROW("Cannot open DBF: " + path.string());
+  }
+
+  int tid_idx = DBFGetFieldIndex(hDBF, "TransectId");
+  if (tid_idx < 0) {
+    SHPClose(hSHP); DBFClose(hDBF);
+    OPENDSAS_THROW("Need to specify TransectId!");
+  }
+  int bid_idx = DBFGetFieldIndex(hDBF, "BaselineId");
+  if (bid_idx < 0) {
+    SHPClose(hSHP); DBFClose(hDBF);
+    OPENDSAS_THROW("Need to specify BaselineId!");
+  }
+
+  int n_entities = 0;
+  SHPGetInfo(hSHP, &n_entities, nullptr, nullptr, nullptr);
+
+  std::vector<std::unique_ptr<TransectLine>> transects;
+  for (int i = 0; i < n_entities; ++i) {
+    int transect_id = DBFReadIntegerAttribute(hDBF, i, tid_idx);
+    int baseline_id = DBFReadIntegerAttribute(hDBF, i, bid_idx);
+
+    SHPObject *obj = SHPReadObject(hSHP, i);
+    if (!obj || obj->nVertices < 2) {
+      if (obj) SHPDestroyObject(obj);
+      continue;
+    }
+    Point left(obj->padfX[0], obj->padfY[0]);
+    Point right(obj->padfX[obj->nVertices - 1], obj->padfY[obj->nVertices - 1]);
+    SHPDestroyObject(obj);
+
+    transects.push_back(std::make_unique<TransectLine>(
+        left, right, transect_id, baseline_id,
+        options.intersection_mode, options.transect_orient));
+  }
+
+  SHPClose(hSHP);
+  DBFClose(hDBF);
+
+  if (transects.size() >= 1) {
+    options.transect_length =
+        transects[0]->leftEdge_.distance_to_point(transects[0]->rightEdge_);
+  }
+  if (transects.size() >= 2) {
+    options.transect_spacing =
+        transects[0]->leftEdge_.distance_to_point(transects[1]->leftEdge_);
+  }
+
+  return transects;
+}
+// GCOVR_EXCL_STOP
+
+// ---- Public dispatch ----
+
+std::vector<std::unique_ptr<TransectLine>> load_transects_from_shp(
+    const std::filesystem::path &transect_shp_path) {
+  auto ext = transect_shp_path.extension().string();
+  if (ext == ".geojson" || ext == ".json") {
+    return load_transects_geojson(transect_shp_path);
+  }
+  return load_transects_shapelib(transect_shp_path);  // GCOVR_EXCL_LINE
 }
 
 void save_transect(const std::vector<std::unique_ptr<TransectLine>> &transects,

--- a/tests/transect.test.cpp
+++ b/tests/transect.test.cpp
@@ -223,4 +223,29 @@ TEST_F(TransectTest, test_load_transects_from_shp) {
                                                 "/sample_transects.geojson"};
   auto transect = load_transects_from_shp(transect_shp_path);
   ASSERT_TRUE(!transect.empty());
+
+  // Empty features array — should throw
+  {
+    auto tmp = std::filesystem::temp_directory_path() / "empty_transects.geojson";
+    std::ofstream f(tmp);
+    f << R"({"type":"FeatureCollection","features":[]})";
+    f.close();
+    ASSERT_THROW(load_transects_from_shp(tmp), std::runtime_error);
+  }
+  // Missing TransectId field — should throw
+  {
+    auto tmp = std::filesystem::temp_directory_path() / "no_tid.geojson";
+    std::ofstream f(tmp);
+    f << R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[0,0],[1,1]]},"properties":{"BaselineId":0}}]})";
+    f.close();
+    ASSERT_THROW(load_transects_from_shp(tmp), std::runtime_error);
+  }
+  // Missing BaselineId field — should throw
+  {
+    auto tmp = std::filesystem::temp_directory_path() / "no_bid.geojson";
+    std::ofstream f(tmp);
+    f << R"({"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[0,0],[1,1]]},"properties":{"TransectId":0}}]})";
+    f.close();
+    ASSERT_THROW(load_transects_from_shp(tmp), std::runtime_error);
+  }
 }


### PR DESCRIPTION
## Summary

- Rewrites `load_transects_from_shp` (`transect.cpp`) to use nlohmann/json (GeoJSON) and shapelib (`.shp`), completing the GDAL removal
- Removes `find_package(GDAL)` and `GDAL::GDAL` from `CMakeLists.txt`
- Removes `libgdal-dev gdal-bin` from both CI jobs; removes stale "Windows disabled" comment from the matrix
- Extends transect tests to cover: empty feature collection, missing `TransectId`, and missing `BaselineId` error paths

**Stack:** [1/3 replace-gdal-1](../compare/replace-gdal-1) → [2/3 replace-gdal-2](../compare/replace-gdal-2) → this

## Test plan
- [ ] CI build passes with no GDAL installed
- [ ] All transect error-path tests pass
- [ ] codecov/patch ≥ 80%