### PR TITLE
Add Windows and macOS to CI matrix; fix macOS OpenMP detection

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -12,16 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        build_type: [Release]
-        c_compiler: [gcc, clang]
         include:
           - os: ubuntu-latest
+            build_type: Release
             c_compiler: gcc
             cpp_compiler: g++
           - os: ubuntu-latest
+            build_type: Release
             c_compiler: clang
             cpp_compiler: clang++
+          - os: macos-latest
+            build_type: Release
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: windows-latest
+            build_type: Release
 
     steps:
       - uses: actions/checkout@v4
@@ -34,15 +39,22 @@ jobs:
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-      # ---------- Linux deps (APT) ----------
+      # ---------- Platform deps ----------
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libomp-dev
 
-      # ---------- Configure / Build / Test ----------
-      - name: Configure CMake
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install libomp
+
+      # ---------- Configure ----------
+      # Linux/macOS: pass the compiler explicitly.
+      # Windows: omit it — CMake auto-selects the VS 2022 generator with MSVC.
+      - name: Configure CMake (Linux / macOS)
+        if: matrix.os != 'windows-latest'
         run: |
           cmake -B ${{ steps.strings.outputs.build-output-dir }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }} \
@@ -50,6 +62,15 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -S ${{ github.workspace }}
 
+      - name: Configure CMake (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          cmake -B "${{ steps.strings.outputs.build-output-dir }}" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -S "${{ github.workspace }}"
+
+      # ---------- Build / Test ----------
       - name: Build
         run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,23 @@ if(NOT shapelib_POPULATED)
 endif()
 
 # OpenMP
+# Apple Clang does not bundle OpenMP; hint CMake to find libomp from Homebrew.
+if(APPLE)
+  execute_process(
+    COMMAND brew --prefix libomp
+    OUTPUT_VARIABLE LIBOMP_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(LIBOMP_PREFIX)
+    set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp")
+    set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp")
+    set(OpenMP_C_LIB_NAMES "omp")
+    set(OpenMP_CXX_LIB_NAMES "omp")
+    set(OpenMP_omp_LIBRARY "${LIBOMP_PREFIX}/lib/libomp.dylib")
+    include_directories("${LIBOMP_PREFIX}/include")
+  endif()
+endif()
 find_package(OpenMP REQUIRED)
 
 # -------------------------


### PR DESCRIPTION
## Summary

- **CMakeLists.txt**: auto-detect libomp from Homebrew on Apple platforms using `execute_process(brew --prefix libomp)` and set the `Xpreprocessor -fopenmp` flags + library path before `find_package(OpenMP REQUIRED)` — users only need `brew install libomp`, no manual CMake flags
- **CI matrix**: replaced the os×compiler cross-product with an explicit `include:` list — ubuntu/gcc, ubuntu/clang, macos/clang, windows/MSVC
- **macOS dep step**: `brew install libomp`
- **Windows configure**: separate step that omits `-DCMAKE_C_COMPILER` so CMake auto-selects the VS 2022 generator with MSVC (no extra `msvc-dev-cmd` action needed); uses `shell: bash` for path consistency with the other steps

## Platform-specific code audit

| Concern | Status |
|---|---|
| `strptime` on Windows | Already handled via `#ifdef _WIN32` / `std::get_time` in `shoreline.cpp` |
| shapelib | Embedded C sources, MSVC-compatible |
| nlohmann/json | Header-only, fully cross-platform |
| `std::filesystem` | C++20, supported on MSVC 2019+, macOS 10.15+ |
| OpenMP on macOS | Fixed by this PR |

## Test plan

- [ ] `ubuntu-latest / gcc` — existing baseline, must stay green
- [ ] `ubuntu-latest / clang` — existing baseline, must stay green
- [ ] `macos-latest / clang` — new; expect green after `brew install libomp` + CMake hints
- [ ] `windows-latest / MSVC` — new; expect green with auto-detected VS 2022 generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)