### PR TITLE
perf: remove OpenMP from build_transect_index

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -192,7 +192,6 @@ void build_transect_index(
     return y_index;
   };
   const auto total = static_cast<std::int64_t>(transects.size());
-#pragma omp parallel for schedule(static)
   for (std::int64_t i = 0; i < total; i++) {
     auto &transect = transects[i];
     const double min_x =


### PR DESCRIPTION
## Summary
- Profiling showed `build_transect_index` took 96 ms with 1 thread and 93 ms with 12 threads — effectively 0× speedup
- The per-iteration body is only a bbox computation (4 comparisons), two index lookups, and a small `vector::reserve` + `emplace_back` loop — far too cheap to amortise OpenMP thread-spawn and barrier cost
- Remove `#pragma omp parallel for schedule(static)` so the function runs serially without that overhead

## Test plan
- [ ] All 35 unit tests pass
- [ ] Confirm `build_transect_index` timing is unchanged or slightly improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)