### PR TITLE
Fix compare.py path in benchmark-compare workflow

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -86,11 +86,12 @@ jobs:
 
       - name: Compare results
         run: |
+          set -euo pipefail
           {
             echo "## Benchmark comparison: \`${{ inputs.branch_a }}\` (A) vs \`${{ inputs.branch_b }}\` (B)"
             echo
             echo '```text'
-            python3 branch-a/build/_deps/benchmark-src/tools/compare.py \
+            python3 _deps_shared/benchmark-src/tools/compare.py \
               --no-color -a benchmarks \
               branch-a/result.json branch-b/result.json
             echo '```'


### PR DESCRIPTION
## Summary
- Fixes `.github/workflows/benchmark-compare.yml`: the `Compare results` step referenced `branch-a/build/_deps/benchmark-src/tools/compare.py`, but the build steps set `-DFETCHCONTENT_BASE_DIR=$GITHUB_WORKSPACE/_deps_shared`, which relocates FetchContent's output there instead. `compare.py` was never found.
- The failure was invisible in the job status because the step piped through `{ ... } | tee -a "$GITHUB_STEP_SUMMARY"` without `pipefail`, so a failing `python3` still yielded a zero exit code for the pipeline. Added `set -euo pipefail` so this can't silently pass again.
- Discovered via run [29185790166](https://github.com/lubyant/OpenDSAS/actions/runs/29185790166): all benchmarks ran fine and both `result.json` artifacts were produced correctly, but the summary table was never generated.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Downloaded the `branch-a`/`branch-b` `result.json` artifacts from run 29185790166 and ran `compare.py` against them locally with the corrected relative path (`_deps_shared/benchmark-src/tools/compare.py` from `$GITHUB_WORKSPACE`) — produces the expected diff table
- [ ] Re-trigger the workflow once merged to confirm the summary renders end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)