### PR TITLE
Publish unversioned release assets for a stable install URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,13 @@ jobs:
           mv dist/macos/dsas-macos-arm64.tar.gz dist/opendsas-${{ github.ref_name }}-macos-arm64.tar.gz
           mv dist/windows/dsas.exe              dist/opendsas-${{ github.ref_name }}-windows-x86_64.exe
 
+      - name: Add unversioned copies (stable /releases/latest/download/ URLs)
+        run: |
+          cp dist/opendsas-${{ github.ref_name }}-linux-x86_64      dist/opendsas-linux-x86_64
+          cp dist/opendsas-${{ github.ref_name }}-linux-arm64       dist/opendsas-linux-arm64
+          cp dist/opendsas-${{ github.ref_name }}-macos-arm64.tar.gz dist/opendsas-macos-arm64.tar.gz
+          cp dist/opendsas-${{ github.ref_name }}-windows-x86_64.exe dist/opendsas-windows-x86_64.exe
+
       - uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -177,5 +184,9 @@ jobs:
             dist/opendsas-${{ github.ref_name }}-linux-arm64
             dist/opendsas-${{ github.ref_name }}-macos-arm64.tar.gz
             dist/opendsas-${{ github.ref_name }}-windows-x86_64.exe
+            dist/opendsas-linux-x86_64
+            dist/opendsas-linux-arm64
+            dist/opendsas-macos-arm64.tar.gz
+            dist/opendsas-windows-x86_64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -26,18 +26,17 @@ OpenDSAS is ideal if:
 
 ### Linux
 
-Download the pre-built static binary from [Releases](https://github.com/lubyant/OpenDSAS/releases):
+Download the pre-built static binary — this URL always points to the latest release:
 
 ```bash
-# Replace vX.Y with the latest version, e.g. v1.4
-curl -LO https://github.com/lubyant/OpenDSAS/releases/download/vX.Y/opendsas-vX.Y-linux-x86_64
-chmod +x opendsas-vX.Y-linux-x86_64
-sudo mv opendsas-vX.Y-linux-x86_64 /usr/local/bin/dsas
+curl -LO https://github.com/lubyant/OpenDSAS/releases/latest/download/opendsas-linux-x86_64
+chmod +x opendsas-linux-x86_64
+sudo mv opendsas-linux-x86_64 /usr/local/bin/dsas
 ```
 
-The binary is fully statically linked — it runs on any Linux distribution (Ubuntu, Debian, RHEL, Alpine, etc.) with no dependencies.
+For ARM (servers, Raspberry Pi), use `opendsas-linux-arm64` instead of `opendsas-linux-x86_64`.
 
-An `arm64` build (`opendsas-vX.Y-linux-arm64`) is also available for ARM servers and Raspberry Pi.
+The binary is fully statically linked — it runs on any Linux distribution (Ubuntu, Debian, RHEL, Alpine, etc.) with no dependencies.
 
 ### macOS
 


### PR DESCRIPTION
## Summary
- Release workflow now also uploads unversioned copies of each artifact (e.g. `opendsas-linux-x86_64` alongside `opendsas-v1.5-linux-x86_64`)
- README's Linux install snippet uses GitHub's stable `/releases/latest/download/` URL, so users no longer need to look up and edit a version number before installing
- `v1.5` release was backfilled with the unversioned assets so the new URL works immediately, without waiting for the next tag

## Test plan
- [x] Verified `curl -fsSLI https://github.com/lubyant/OpenDSAS/releases/latest/download/opendsas-linux-x86_64` returns a 302 redirect to the current asset
- [ ] Confirm the next tagged release (`v1.6`+) publishes both versioned and unversioned assets via the updated workflow