### PR TITLE
Add pip distribution via platform-specific wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,84 @@ jobs:
           name: windows-x86_64
           path: build/Release/dsas.exe
 
+  # ── pip packaging ────────────────────────────────────────────────────────────
+  # Wraps each static binary in a platform-specific wheel (binary embedded,
+  # tiny launcher that execs it) so `pip install opendsas` works everywhere the
+  # raw binary download works. Tag-only: version comes from the git tag.
+  package-pip:
+    name: Package pip wheel — ${{ matrix.target.plat_tag }}
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-linux, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - { plat_tag: manylinux2014_x86_64,  artifact: dsas-linux-static-x86_64, binname: dsas,     archive: none }
+          - { plat_tag: manylinux2014_aarch64, artifact: dsas-linux-static-arm64,  binname: dsas,     archive: none }
+          - { plat_tag: macosx_11_0_arm64,     artifact: macos-arm64,              binname: dsas,     archive: tar.gz }
+          - { plat_tag: win_amd64,             artifact: windows-x86_64,           binname: dsas.exe, archive: none }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.target.artifact }}
+          path: artifact
+
+      - name: Stage binary
+        run: |
+          mkdir -p python/dist-bin
+          if [ "${{ matrix.target.archive }}" = "tar.gz" ]; then
+            tar -xzf artifact/*.tar.gz -C artifact
+          fi
+          cp "artifact/${{ matrix.target.binname }}" "python/dist-bin/${{ matrix.target.binname }}"
+          chmod +x "python/dist-bin/${{ matrix.target.binname }}" || true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set package version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" python/src/opendsas/__init__.py
+
+      - name: Build and retag wheel
+        run: |
+          pip install --upgrade build wheel
+          python -m build --wheel -o dist python
+          python -m wheel tags --python-tag py3 --abi-tag none \
+            --platform-tag ${{ matrix.target.plat_tag }} --remove dist/*.whl
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pip-wheel-${{ matrix.target.plat_tag }}
+          path: dist/*.whl
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: package-pip
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pip-wheel-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
   # ── Release ────────────────────────────────────────────────────────────────
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-linux, verify-linux, build-macos, build-windows]
+    needs: [build-linux, verify-linux, build-macos, build-windows, package-pip]
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -162,6 +236,12 @@ jobs:
         with:
           name: windows-x86_64
           path: dist/windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pip-wheel-*
+          path: dist/wheels
+          merge-multiple: true
 
       - name: Rename artifacts
         run: |
@@ -188,5 +268,6 @@ jobs:
             dist/opendsas-linux-arm64
             dist/opendsas-macos-arm64.tar.gz
             dist/opendsas-windows-x86_64.exe
+            dist/wheels/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@
 
 # Build directory
 build/
+
+# Python packaging staging/output
+python/dist-bin/
+python/dist/
+python/src/opendsas.egg-info/
+python/src/opendsas/bin/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ OpenDSAS is ideal if:
 
 ## 📦 Installation
 
+### pip (Linux, macOS arm64, Windows)
+
+```bash
+pip install opendsas
+```
+
+This installs the same static `dsas` binary published in [Releases](https://github.com/lubyant/OpenDSAS/releases), wrapped in a platform wheel — no compiler or build step required.
+
 ### Linux
 
 Download the pre-built static binary — this URL always points to the latest release:

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 lubyant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,29 @@
+# opendsas
+
+Pip-installable wrapper around the [OpenDSAS](https://github.com/lubyant/OpenDSAS) `dsas` CLI —
+a high-performance, cross-platform reimplementation of the USGS Digital Shoreline Analysis System.
+
+This package does not compile anything: it bundles the same statically-linked `dsas` binary
+published in [GitHub Releases](https://github.com/lubyant/OpenDSAS/releases), and installs a
+`dsas` console script that execs it directly.
+
+## Install
+
+```bash
+pip install opendsas
+```
+
+## Usage
+
+```bash
+dsas --baseline baseline.shp --shoreline shoreline.shp \
+     --transect-length 1000 --transect-spacing 10
+```
+
+See the [main README](https://github.com/lubyant/OpenDSAS#readme) for full CLI documentation.
+
+## Supported platforms
+
+- Linux x86_64 / aarch64
+- macOS arm64 (Apple Silicon)
+- Windows x86_64

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opendsas"
+dynamic = ["version"]
+description = "High-performance Digital Shoreline Analysis System CLI — static binary, packaged for pip"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+authors = [{ name = "Boyuan Lu" }]
+keywords = ["dsas", "shoreline", "gis", "coastal", "cli"]
+classifiers = [
+  "Environment :: Console",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: Microsoft :: Windows",
+  "Topic :: Scientific/Engineering :: GIS",
+]
+
+[project.urls]
+Homepage = "https://github.com/lubyant/OpenDSAS"
+Repository = "https://github.com/lubyant/OpenDSAS"
+Issues = "https://github.com/lubyant/OpenDSAS/issues"
+
+[project.scripts]
+dsas = "opendsas:main"
+
+[tool.hatch.version]
+path = "src/opendsas/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opendsas"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"dist-bin" = "opendsas/bin"

--- a/python/src/opendsas/__init__.py
+++ b/python/src/opendsas/__init__.py
@@ -1,0 +1,32 @@
+"""Thin launcher that execs the static ``dsas`` binary bundled in this wheel."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+__version__ = "0.0.0"
+
+
+def _binary_path() -> Path:
+    bin_dir = Path(__file__).parent / "bin"
+    candidate = bin_dir / ("dsas.exe" if os.name == "nt" else "dsas")
+    if not candidate.exists():
+        raise FileNotFoundError(
+            f"bundled dsas binary not found at {candidate} — this wheel appears "
+            "to be corrupt, or was installed for the wrong platform/architecture"
+        )
+    return candidate
+
+
+def main() -> None:
+    binary = _binary_path()
+    if os.name != "nt":
+        os.chmod(binary, 0o755)
+        os.execv(str(binary), [str(binary), *sys.argv[1:]])
+    else:
+        raise SystemExit(subprocess.run([str(binary), *sys.argv[1:]]).returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Wraps the existing static `dsas` binaries in a new `python/` package (`opendsas`): a thin `dsas` console-script launcher that `exec`s the bundled binary, no compilation needed.
- Extends `release.yml` with a `package-pip` matrix job that builds a wheel per platform and retags it (`wheel tags`) to `manylinux2014_x86_64`, `manylinux2014_aarch64`, `macosx_11_0_arm64`, and `win_amd64`, and a `publish-pypi` job that publishes them to PyPI via trusted publishing (OIDC, no token secret) on tag push.
- Wheels are also attached to the GitHub release alongside the existing raw binaries.
- README gets a `pip install opendsas` section.

## Setup required before this can publish
PyPI trusted publishing must be registered once at https://pypi.org/manage/account/publishing/ for project `opendsas`, owner `lubyant`, repo `OpenDSAS`, workflow `release.yml`, environment `pypi`. `opendsas` is currently unclaimed on PyPI. Until that's configured, `package-pip` and the release-asset attachment still work — only the final `publish-pypi` step will fail.

## Test plan
- [x] Built and retagged a wheel locally with a stub binary (`python -m build` + `python -m wheel tags`), confirmed the resulting `.whl` has the right platform tag and file layout (`opendsas/bin/dsas` present, executable).
- [x] Installed the wheel into a clean venv and confirmed `dsas <args>` execs the bundled binary and forwards args correctly.
- [ ] End-to-end verification of the CI jobs (`package-pip` / `publish-pypi`) on an actual tag push, once trusted publishing is registered on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)