### PR TITLE
Bump Homebrew formula to v1.7

### DIFF
--- a/Formula/opendsas.rb
+++ b/Formula/opendsas.rb
@@ -4,9 +4,9 @@ class Opendsas < Formula
   # `version` is declared before `url` so the url can interpolate it — a
   # single source of truth for the release. (This trips Homebrew's
   # ComponentsOrder audit hint, which wants url first; harmless for a tap.)
-  version "1.6"
+  version "1.7"
   url "https://github.com/lubyant/OpenDSAS/releases/download/v#{version}/opendsas-v#{version}-macos-arm64.tar.gz"
-  sha256 "64a285fc8615c9a6d8997126ceaf94f72c68891e3dc5cdbb09fa1dcaf2063a23"
+  sha256 "b2d5b255c60d4738df7799a9cff53fb6082f00399bd49097a5230b3fc3d3f008"
   license "MIT"
 
   # Track the newest GitHub release so `brew livecheck` / `bump-formula-pr`


### PR DESCRIPTION
## Summary
- Bumps `Formula/opendsas.rb` from v1.6 to v1.7, matching the just-published [v1.7 release](https://github.com/lubyant/OpenDSAS/releases/tag/v1.7) (also now available via `pip install opendsas`).
- Updates `sha256` to match `opendsas-v1.7-macos-arm64.tar.gz`.

## Test plan
- [x] Downloaded `opendsas-v1.7-macos-arm64.tar.gz` from the v1.7 release and verified its sha256 matches the value in this diff.
- [ ] `brew install lubyant/opendsas/opendsas` on Apple Silicon after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)